### PR TITLE
Fix license field cargo

### DIFF
--- a/.changes/cli-license-field-workspace.md
+++ b/.changes/cli-license-field-workspace.md
@@ -1,0 +1,6 @@
+---
+"tauri-cli": patch:bug
+"@tauri-apps/cli": patch:bug
+---
+
+Allow license field in Cargo.toml to be `{ workspace = true }`

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -612,6 +612,7 @@ struct WorkspacePackageSettings {
   description: Option<String>,
   homepage: Option<String>,
   version: Option<String>,
+  license: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -930,7 +931,18 @@ impl RustAppSettings {
           })
           .unwrap()
       }),
-      license: cargo_package_settings.license.clone(),
+      license: cargo_package_settings.license.clone().map(|license| {
+        license
+          .resolve("license", || {
+            ws_package_settings
+              .as_ref()
+              .and_then(|v| v.license.clone())
+              .ok_or_else(|| {
+                anyhow::anyhow!("Couldn't inherit value for `license` from workspace")
+              })
+          })
+          .unwrap()
+      }),
       default_run: cargo_package_settings.default_run.clone(),
     };
 

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -635,7 +635,7 @@ pub struct CargoPackageSettings {
   /// the package's authors.
   pub authors: Option<MaybeWorkspace<Vec<String>>>,
   /// the package's license.
-  pub license: Option<String>,
+  pub license: Option<MaybeWorkspace<String>>,
   /// the default binary to run.
   pub default_run: Option<String>,
 }

--- a/tooling/cli/src/interface/rust.rs
+++ b/tooling/cli/src/interface/rust.rs
@@ -937,9 +937,7 @@ impl RustAppSettings {
             ws_package_settings
               .as_ref()
               .and_then(|v| v.license.clone())
-              .ok_or_else(|| {
-                anyhow::anyhow!("Couldn't inherit value for `license` from workspace")
-              })
+              .ok_or_else(|| anyhow::anyhow!("Couldn't inherit value for `license` from workspace"))
           })
           .unwrap()
       }),


### PR DESCRIPTION
<!--
Update "[ ]" to "[x]" to check a box

Please make sure to read the Pull Request Guidelines: https://github.com/tauri-apps/tauri/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

### What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Docs
- [ ] New Binding issue #___
- [ ] Code style update
- [ ] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

### Does this PR introduce a breaking change?

- [ ] Yes, and the changes were approved in issue #___
- [x] No

### Checklist
- [ ] When resolving issues, they are referenced in the PR's title (e.g `fix: remove a typo, closes #___, #___`)
- [ ] A change file is added if any packages will require a version bump due to this PR per [the instructions in the readme](https://github.com/tauri-apps/tauri/blob/dev/.changes/readme.md).
- [x] I have added a convincing reason for adding this feature, if necessary

### Other information

Fixed bug for non "workspace friendly" license field. Now license field with workspace = true should work.